### PR TITLE
Trace logging

### DIFF
--- a/src/metal_filesystem_pipeline/file_data_sink.hpp
+++ b/src/metal_filesystem_pipeline/file_data_sink.hpp
@@ -12,12 +12,13 @@ namespace metal {
 class FileDataSink : public DataSink {
 
   // Common API
- public:
- protected:
+public:
+protected:
   fpga::AddressType addressType() override { return fpga::AddressType::NVMe; }
 
   void configure(SnapAction &action) override;
   void finalize(SnapAction &action) override;
+  void seek(uint64_t offset) { _address = offset; }
 
   std::vector<mtl_file_extent> _extents;
 
@@ -27,13 +28,13 @@ public:
 
 
   // API to be used when building file pipelines (filename-based)
- public:
+public:
   explicit FileDataSink(std::string filename, uint64_t offset, uint64_t size = 0);
 
   void prepareForTotalProcessingSize(size_t size) override;
   void setSize(size_t size) override;
 
- protected:
+protected:
   void loadExtents();
 
   std::string _filename;

--- a/src/metal_filesystem_pipeline/file_data_source.hpp
+++ b/src/metal_filesystem_pipeline/file_data_source.hpp
@@ -5,24 +5,25 @@ namespace metal {
 
 class FileDataSource : public DataSource {
 
-  // Common API
- public:
- protected:
-   fpga::AddressType addressType() override { return fpga::AddressType::NVMe; }
+// Common API
+public:
+protected:
+  fpga::AddressType addressType() override { return fpga::AddressType::NVMe; }
 
-   void configure(SnapAction &action) override;
-   void finalize(SnapAction &action) override;
+  void configure(SnapAction &action) override;
+  void finalize(SnapAction &action) override;
+  void seek(uint64_t offset) { _address = offset; }
 
-   std::vector<mtl_file_extent> _extents;
+  std::vector<mtl_file_extent> _extents;
 
 
   // API to be used from PipelineStorage (extent list-based)
- public:
+public:
   explicit FileDataSource(std::vector<mtl_file_extent> &extents, uint64_t offset, uint64_t size);
 
 
   // API to be used when building file pipelines (filename-based)
- public:
+public:
   explicit FileDataSource(std::string filename, uint64_t offset, uint64_t size = 0);
   size_t reportTotalSize() override;
 

--- a/src/metal_pipeline/snap_action.cpp
+++ b/src/metal_pipeline/snap_action.cpp
@@ -12,6 +12,8 @@
 namespace metal {
 
 SnapAction::SnapAction(snap_action_type_t action_type, int card_no) {
+    spdlog::trace("Allocating CXL device /dev/cxl/afu{}.0s...", card_no);
+
     char device[128];
     snprintf(device, sizeof(device)-1, "/dev/cxl/afu%d.0s", card_no);
 
@@ -19,6 +21,8 @@ SnapAction::SnapAction(snap_action_type_t action_type, int card_no) {
     if (!_card) {
         throw std::runtime_error("Failed to open card");
     }
+
+    spdlog::trace("Attaching to Metal FS action...");
 
     auto action_irq = (snap_action_flag_t)(SNAP_ACTION_DONE_IRQ | SNAP_ATTACH_IRQ);
     _action = snap_attach_action(_card, action_type, action_irq, 10);


### PR DESCRIPTION
This adds a command line argument to the `metal_fs` executable to specify the log level. FUSE operations now produce trace log entries.

Also added a seek method for FileDataSink/Source that is useful for benchmarking (i.e. writing at/reading from the same file offset on each Pipeline invocation).