### PR TITLE
Publish filesystem driver as Docker image for ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: generic
+
+os: linux
+arch: ppc64le
+
+services:
+- docker
+
+script:
+- docker build -t metalfs/metalfs:latest .

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,15 @@ arch: ppc64le
 services:
 - docker
 
+env:
+  global:
+    secure: 5/+AXMPf7j9Ukv+FT3HOZmgmir59ZwwM+W30IiUabuxrGNwykTPouGp9RzcYhRV61zEzlaYV/Y7XXfIsGMmvFK6Yl0esn8c/f8S1ryjOnwqqIRY3dLj8V8FDfBUp9AQCtPXsLEM3O2mwElp4Yg3EFep4QSxY4Q7C78bu9ko8s2K25XsiTKOaXAKx2arrTRXyZMfZlTOM+iYTEoDPiDuUeuiuvkLgECzAjYOSPzwo5ZwkHhplpFmG2ogqbLdBdOGAQrxLjlGgGEoroTWFAHEr5ym/4Z2MyB8xxr17MuVDjqdABJf7Q10s8oTwXE2uqlJ89toDrlWCfOjzh6iAKjip87zP7wDAzf8nn9d1NDgwxeBJos9HZC3HPIy8aLpMSJBwewnibVBHxXXBv4vTKnt5ypGPXLnzviaJNypdVguVGlkVmwgjATx+8hALCe5UgP2qxdsZZGNNuAGRa/Urvu9YhjERivCsZMFZfD719KZ8pnIhvMVyPUD4Po0mX2wflW2CKXZXWHwRXRpt8XzcR9wUib4hY8BRIUPZk3hAq98X0wstVdSHYwt51UAwvpMgnbPS4+tItMRQt8MLRu4lgiGs1dsnOpIKINlXrYSP6eu0j5de2XkwpwyNnGBfGTSEZIIxk+C/JDLk9d8mR1LAoTGxmaD5OzQEqmkjaHqr2cjEJbM=
+
 script:
 - docker build -t metalfs/metalfs:latest .
+
+deploy:
+  - provider: script
+    on:
+      tags: true
+    script: bash scripts/docker_push_ci

--- a/scripts/docker_push_ci
+++ b/scripts/docker_push_ci
@@ -1,0 +1,5 @@
+#! /bin/bash
+
+echo $DOCKER_PASSWORD | docker login -u rs22 --password-stdin
+docker tag  metalfs/metalfs:latest metalfs/metalfs:$TRAVIS_TAG
+docker push metalfs/metalfs:$TRAVIS_TAG


### PR DESCRIPTION
This updates the Dockerfile and introduces Travis CI builds and automated publishing of resulting Docker images for each tagged release.