### PR TITLE
Add metal_cat pseudo-operator

### DIFF
--- a/docker/runtime/Dockerfile.ppc64le
+++ b/docker/runtime/Dockerfile.ppc64le
@@ -35,7 +35,6 @@ RUN mkdir build \
 FROM ubuntu:bionic
 
 COPY --from=build /install/metal-driver /usr/local/bin/
-COPY --from=build /install/metal-driver-placeholder /usr/local/bin/
 COPY --from=build /install/lib/ /usr/local/lib/
 RUN ldconfig
 

--- a/src/metal-driver-messages/proto/Messages.proto
+++ b/src/metal-driver-messages/proto/Messages.proto
@@ -24,6 +24,8 @@ message RegistrationResponse {
 
   optional string input_buffer_filename = 3;
   optional string output_buffer_filename = 4;
+
+  optional string agent_read_filename = 5;
 }
 
 message ProcessingRequest {

--- a/src/metal-driver-placeholder/CMakeLists.txt
+++ b/src/metal-driver-placeholder/CMakeLists.txt
@@ -98,14 +98,3 @@ target_link_libraries(${target}
     PRIVATE
     ${DEFAULT_LINKER_OPTIONS}
 )
-
-
-#
-# Deployment
-#
-
-# Executable
-install(TARGETS ${target}
-    RUNTIME DESTINATION ${INSTALL_BIN} COMPONENT runtime
-    BUNDLE  DESTINATION ${INSTALL_BIN} COMPONENT runtime
-)

--- a/src/metal-driver-placeholder/operator_agent.cpp
+++ b/src/metal-driver-placeholder/operator_agent.cpp
@@ -290,7 +290,7 @@ int main(int argc, char *argv[]) {
       socket.receiveMessage<metal::MessageType::RegistrationResponse>();
 
   if (response.has_error_msg()) {
-    fprintf(stderr, "%s", response.error_msg().c_str());
+    std::cerr << response.error_msg();
   }
 
   if (!response.valid()) {
@@ -321,7 +321,7 @@ int main(int argc, char *argv[]) {
   // Read the first input
   if (inputBuffer != std::nullopt) {
     bytesRead = fread(inputBuffer.value().current(), sizeof(char),
-                       inputBuffer.value().size(), infd);
+                      inputBuffer.value().size(), infd);
     eof = feof(infd) != 0;
     inputBuffer.value().swap();
   }
@@ -348,7 +348,7 @@ int main(int argc, char *argv[]) {
     }
 
     if (processingResponse.has_message()) {
-      fprintf(stderr, "%s", processingResponse.message().c_str());
+      std::cerr << processingResponse.message();
     }
 
     if (processingResponse.eof()) {
@@ -358,7 +358,7 @@ int main(int argc, char *argv[]) {
     // Read the next input
     if (inputBuffer != std::nullopt && !eof) {
       bytesRead = fread(inputBuffer.value().current(), sizeof(char),
-                         inputBuffer.value().size(), infd);
+                        inputBuffer.value().size(), infd);
       eof = feof(infd) != 0;
       inputBuffer.value().swap();
     }
@@ -368,9 +368,10 @@ int main(int argc, char *argv[]) {
       processingResponse =
           socket.receiveMessage<metal::MessageType::ProcessingResponse>();
     } catch (std::exception &ex) {
-      fprintf(stderr,
-              "An error occurred during pipeline execution. Please check the "
-              "filesystem driver logs.\n");
+      std::cerr
+          << "An error occurred during pipeline execution. Please check the "
+             "filesystem driver logs."
+          << std::endl;
     }
   }
 

--- a/src/metal-driver/CMakeLists.txt
+++ b/src/metal-driver/CMakeLists.txt
@@ -17,6 +17,7 @@ message(STATUS "Executable ${target}")
 
 add_custom_command(
     OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/metal-driver-placeholder.hex
+    DEPENDS $<TARGET_FILE:${META_PROJECT_NAME}::metal-driver-placeholder>
     COMMAND cat $<TARGET_FILE:${META_PROJECT_NAME}::metal-driver-placeholder> | xxd -i - ${CMAKE_CURRENT_BINARY_DIR}/metal-driver-placeholder.hex
     COMMENT "Generating binary include from ${META_PROJECT_NAME}::metal-driver-placeholder"
 )

--- a/src/metal-driver/metal_fuse_operations.cpp
+++ b/src/metal-driver/metal_fuse_operations.cpp
@@ -436,6 +436,7 @@ void Context::initialize(bool in_memory, std::string metadata_dir, int card) {
     _operators.emplace(op.first);
   }
   _operators.emplace(DatagenOperator::id());
+  _operators.emplace(MetalCatOperator::id());
 
   _files_dirname = "files";
   _operators_dirname = "operators";

--- a/src/metal-driver/operator_agent.cpp
+++ b/src/metal-driver/operator_agent.cpp
@@ -91,7 +91,7 @@ void OperatorAgent::createOutputBuffer() {
 void OperatorAgent::setInputFile(const std::string &input) {
   auto absPath = resolvePath(input);
 
-  char actualpath[PATH_MAX + 1];
+  char actualpath[PATH_MAX];
   char *ptr;
   ptr = realpath(absPath.c_str(), actualpath);
 

--- a/src/metal-driver/operator_agent.hpp
+++ b/src/metal-driver/operator_agent.hpp
@@ -31,12 +31,14 @@ class OperatorAgent : public std::enable_shared_from_this<OperatorAgent> {
   void setError(const std::string &error) { _error = error; }
   const std::string &internalInputFile() const { return _internalInputFile; }
   const std::string &internalOutputFile() const { return _internalOutputFile; }
+  const std::string &agentLoadFile() const { return _agentLoadFile; }
   const std::string &operatorType() const { return _operatorType; }
   bool terminated() const { return _terminated; }
   void setTerminated() { _terminated = true; }
 
   void createInputBuffer();
   void createOutputBuffer();
+  void setInputFile(const std::string &input);
 
   void sendRegistrationResponse(RegistrationResponse &message);
   ProcessingRequest receiveProcessingRequest();
@@ -55,6 +57,7 @@ class OperatorAgent : public std::enable_shared_from_this<OperatorAgent> {
 
   std::string _internalInputFile;
   std::string _internalOutputFile;
+  std::string _agentLoadFile;
 
   std::shared_ptr<OperatorAgent> _outputAgent;
   uint _outputAgentPid;

--- a/src/metal-driver/pipeline_builder.cpp
+++ b/src/metal-driver/pipeline_builder.cpp
@@ -133,15 +133,7 @@ ConfiguredPipeline PipelineBuilder::configure() {
 
   // Establish pipeline data source and sink
   result.dataSourceAgent = orderedOperatorSpecsAndAgents.front().second;
-  if (result.dataSourceAgent->internalInputFile().empty() &&
-      !DatagenOperator::isDatagenAgent(*result.dataSourceAgent)) {
-    result.dataSourceAgent->createInputBuffer();
-  }
-
   result.dataSinkAgent = orderedOperatorSpecsAndAgents.back().second;
-  if (result.dataSinkAgent->internalOutputFile().empty()) {
-    result.dataSinkAgent->createOutputBuffer();
-  }
 
   // Validate datagen and metal_cat (if necessary)
   if (DatagenOperator::isDatagenAgent(*result.dataSourceAgent)) {
@@ -150,6 +142,15 @@ ConfiguredPipeline PipelineBuilder::configure() {
   } else if (MetalCatOperator::isMetalCatAgent(*result.dataSourceAgent)) {
     MetalCatOperator::validate(*result.dataSourceAgent);
     MetalCatOperator::setInputFile(*result.dataSourceAgent);
+  }
+
+  // Create memory-mapped buffers if necessary
+  if (result.dataSourceAgent->internalInputFile().empty() &&
+      !DatagenOperator::isDatagenAgent(*result.dataSourceAgent)) {
+    result.dataSourceAgent->createInputBuffer();
+  }
+  if (result.dataSinkAgent->internalOutputFile().empty()) {
+    result.dataSinkAgent->createOutputBuffer();
   }
 
   // Tell agents that they're accepted

--- a/src/metal-driver/pipeline_loop.cpp
+++ b/src/metal-driver/pipeline_loop.cpp
@@ -40,6 +40,16 @@ void PipelineLoop::run() {
     } else {
       dataSource.setProfilingEnabled(isProfilingEnabled);
     }
+  } else if (MetalCatOperator::isMetalCatAgent(*_pipeline.dataSourceAgent)) {
+    auto isProfilingEnabled =
+        MetalCatOperator::isProfilingEnabled(*_pipeline.dataSourceAgent);
+    if (_pipeline.pipeline->operators().empty()) {
+      // Special handling to be able to deliver profiling results back to the
+      // agent
+      dataSink.setProfilingEnabled(isProfilingEnabled);
+    } else {
+      dataSource.setProfilingEnabled(isProfilingEnabled);
+    }
   }
 
   // Wait until all idle clients signal ready
@@ -50,7 +60,7 @@ void PipelineLoop::run() {
   }
 
   for (;;) {
-    auto [outputSize, endOfInput ] = runner.run(dataSource, dataSink);
+    auto [outputSize, endOfInput] = runner.run(dataSource, dataSink);
     (void)outputSize;
 
     if (endOfInput) {

--- a/src/metal-driver/pseudo_operators.cpp
+++ b/src/metal-driver/pseudo_operators.cpp
@@ -23,10 +23,17 @@ uint64_t DatagenOperator::datagenLength(OperatorAgent &agent) {
   return optionValues["length"].as<uint64_t>();
 }
 
+void DatagenOperator::setInputFile(OperatorAgent &agent) {
+  auto optionValues = parseOptions(agent);
+  auto input = optionValues["input"].as<std::string>();
+  if (input.size()) {
+    agent.setInputFile(input);
+  }
+}
+
 cxxopts::ParseResult DatagenOperator::parseOptions(OperatorAgent &agent) {
-  auto options =
-      cxxopts::Options(id(),
-                       "Generate data on the FPGA for benchmarking operators.");
+  auto options = cxxopts::Options(
+      id(), "Generate data on the FPGA for benchmarking operators.");
 
   options.add_option("", "h", "help", "Print help",
                      cxxopts::value<bool>()->default_value("false"), "");
@@ -35,6 +42,47 @@ cxxopts::ParseResult DatagenOperator::parseOptions(OperatorAgent &agent) {
   options.add_option("", "l", "length",
                      "The amount of data to generate, in bytes",
                      cxxopts::value<uint64_t>()->default_value("4096"), "");
+  options.add_option("", "", "input", "Input",
+                     cxxopts::value<std::string>()->default_value(""), "");
+
+  options.parse_positional({"input"});
+
+  return agent.parseOptions(options);
+}
+
+bool MetalCatOperator::isMetalCatAgent(const OperatorAgent &agent) {
+  return agent.operatorType() == id();
+}
+
+void MetalCatOperator::validate(OperatorAgent &agent) {
+  // This will throw if something is wrong
+  parseOptions(agent);
+}
+
+bool MetalCatOperator::isProfilingEnabled(OperatorAgent &agent) {
+  auto optionValues = parseOptions(agent);
+  return optionValues["profile"].as<bool>();
+}
+
+void MetalCatOperator::setInputFile(OperatorAgent &agent) {
+  auto optionValues = parseOptions(agent);
+  auto input = optionValues["input"].as<std::string>();
+  if (input.size()) {
+    agent.setInputFile(input);
+  }
+}
+
+cxxopts::ParseResult MetalCatOperator::parseOptions(OperatorAgent &agent) {
+  auto options = cxxopts::Options(id(), "Loop data through the FPGA.");
+
+  options.add_option("", "h", "help", "Print help",
+                     cxxopts::value<bool>()->default_value("false"), "");
+  options.add_option("", "p", "profile", "Enable profiling",
+                     cxxopts::value<bool>()->default_value("false"), "");
+  options.add_option("", "", "input", "Input",
+                     cxxopts::value<std::string>()->default_value(""), "");
+
+  options.parse_positional({"input"});
 
   return agent.parseOptions(options);
 }

--- a/src/metal-driver/pseudo_operators.hpp
+++ b/src/metal-driver/pseudo_operators.hpp
@@ -15,6 +15,19 @@ class DatagenOperator {
   static void validate(OperatorAgent &agent);
   static bool isProfilingEnabled(OperatorAgent &agent);
   static uint64_t datagenLength(OperatorAgent &agent);
+  static void setInputFile(OperatorAgent &agent);
+
+ protected:
+  static cxxopts::ParseResult parseOptions(OperatorAgent &agent);
+};
+
+class MetalCatOperator {
+ public:
+  static std::string id() { return "metal_cat"; }
+  static bool isMetalCatAgent(const OperatorAgent &agent);
+  static void validate(OperatorAgent &agent);
+  static bool isProfilingEnabled(OperatorAgent &agent);
+  static void setInputFile(OperatorAgent &agent);
 
  protected:
   static cxxopts::ParseResult parseOptions(OperatorAgent &agent);

--- a/src/metal-pipeline/include/metal-pipeline/snap_action.hpp
+++ b/src/metal-pipeline/include/metal-pipeline/snap_action.hpp
@@ -30,8 +30,8 @@ class METAL_PIPELINE_API SnapAction {
   static std::string mapTypeToString(fpga::MapType mapType);
 
  protected:
-  std::string jobTypeToString(fpga::JobType job);
-  std::string snapReturnCodeToString(int rc);
+  static std::string jobTypeToString(fpga::JobType job);
+  static std::string snapReturnCodeToString(int rc);
 
   struct snap_action *_action;
   struct snap_card *_card;

--- a/src/metal-pipeline/src/pipeline.cpp
+++ b/src/metal-pipeline/src/pipeline.cpp
@@ -57,6 +57,8 @@ uint64_t Pipeline::run(DataSource dataSource, DataSink dataSink,
     enable_mask |= (1u << op.userOperator().spec().streamID());
   }
 
+  spdlog::debug("Running Pipeline");
+
   auto sourceAddress = dataSource.address(),
        destinationAddress = dataSink.address();
 

--- a/src/metal-pipeline/src/profiling_pipeline_runner.cpp
+++ b/src/metal-pipeline/src/profiling_pipeline_runner.cpp
@@ -181,7 +181,7 @@ std::string ProfilingPipelineRunner::formatProfilingResults() {
   std::stringstream result;
 
   result << "STREAM\tBYTES TRANSFERRED  ACTIVE CYCLES  DATA WAIT      CONSUMER "
-            "WAIT  TOTAL CYCLES  MB/s"
+            "WAIT  TOTAL CYCLES  MiB/s"
          << std::endl;
 
   result << string_format(

--- a/src/metal-pipeline/src/snap_action.cpp
+++ b/src/metal-pipeline/src/snap_action.cpp
@@ -63,7 +63,7 @@ void SnapAction::executeJob(fpga::JobType jobType, const void *parameters,
                             uint64_t *directDataOut1) {
   spdlog::debug("Starting job {}...", jobTypeToString(jobType));
 
-  fpga::Job mjob;
+  fpga::Job mjob{};
   mjob.job_type = jobType;
   mjob.job_address = reinterpret_cast<uint64_t>(parameters);
   mjob.source = source;

--- a/src/metal-pipeline/src/snap_pipeline_runner.cpp
+++ b/src/metal-pipeline/src/snap_pipeline_runner.cpp
@@ -45,11 +45,16 @@ std::pair<uint64_t, bool> SnapPipelineRunner::run(DataSourceContext &dataSource,
   }
 
   dataSource.configure(action, initialize);
-  dataSink.configure(action, dataSource.dataSource().address().size,
-                     initialize);
+
+  auto size = dataSource.dataSource().address().size;
+  auto endOfInput = dataSource.endOfInput();
+  if (size == 0) {
+    return std::make_pair(0, endOfInput);
+  }
+
+  dataSink.configure(action, size, initialize);
 
   _initialized = true;
-  auto endOfInput = dataSource.endOfInput();
 
   preRun(action, dataSource, dataSink, initialize);
   auto outputSize =


### PR DESCRIPTION
This adds a pseudo-operator that can be used to profile the passthrough-performance of the FPGA overlay. Furthermore, it allows to pass input file names as (unnamed) operator parameters on the command line.